### PR TITLE
check expect before grading

### DIFF
--- a/scripts/grade/lab1.sh
+++ b/scripts/grade/lab1.sh
@@ -14,7 +14,7 @@ BOLD='\033[1m'
 NONE='\033[0m'
 
 if ! type expect >/dev/null 2>&1; then
-    echo -e "${BOLD} Please install expect before grading. (e.g. sudo apt-get install expect) ${NONE}"
+    echo -e "${BOLD} Please install expect before grading. (e.g.， sudo apt-get install expect) ${NONE}"
     exit 1
 fi
 

--- a/scripts/grade/lab1.sh
+++ b/scripts/grade/lab1.sh
@@ -13,6 +13,11 @@ ORANGE='\033[0;33m'
 BOLD='\033[1m'
 NONE='\033[0m'
 
+if ! type expect >/dev/null 2>&1; then
+    echo -e "${BOLD} Please install expect before grading. (e.g. sudo apt-get install expect) ${NONE}"
+    exit 1
+fi
+
 grade_dir=$(dirname $0)
 
 echo -e "${BOLD}===============${NONE}"


### PR DESCRIPTION
First check 'expect', otherwise the grading script will mistakenly take the non-zero value returned by the shell due to an error as the score.