### PR TITLE
Fix typos in Lab 1 and Lab 2

### DIFF
--- a/Lab1/kernel/arch/aarch64/boot/raspi3/init/init_c.c
+++ b/Lab1/kernel/arch/aarch64/boot/raspi3/init/init_c.c
@@ -19,13 +19,13 @@
 char boot_cpu_stack[PLAT_CPU_NUMBER][INIT_STACK_SIZE] ALIGN(4096);
 
 /*
- * Initialize these varibles in order to make them not in .bss section.
+ * Initialize these variables in order to make them not in .bss section.
  * So, they will have concrete initial value even on real machine.
  *
  * Non-primary CPUs will spin until they see the secondary_boot_flag becomes
  * non-zero which is set in kernel (see enable_smp_cores).
  *
- * The secondary_boot_flag is initilized as {NOT_BSS, 0, 0, ...}.
+ * The secondary_boot_flag is initialized as {NOT_BSS, 0, 0, ...}.
  */
 #define NOT_BSS (0xBEEFUL)
 long secondary_boot_flag[PLAT_CPU_NUMBER] = {NOT_BSS};
@@ -85,7 +85,7 @@ void init_c(void)
 
 	wakeup_other_cores();
 
-	/* Initialize Kernell Page Table. */
+	/* Initialize Kernel Page Table. */
 	uart_send_string("[BOOT] Install kernel page table\r\n");
 	init_kernel_pt();
 

--- a/Lab1/kernel/arch/aarch64/boot/raspi3/init/mmu.c
+++ b/Lab1/kernel/arch/aarch64/boot/raspi3/init/mmu.c
@@ -67,7 +67,7 @@ void init_kernel_pt(void)
                         | UXN /* Unprivileged execute never */
                         | ACCESSED /* Set access flag */
                         | NG /* Mark as not global */
-                        | INNER_SHARABLE /* Sharebility */
+                        | INNER_SHARABLE /* Shareability */
                         | NORMAL_MEMORY /* Normal memory */
                         | IS_VALID;
         }

--- a/Lab2/kernel/arch/aarch64/mm/page_table.c
+++ b/Lab2/kernel/arch/aarch64/mm/page_table.c
@@ -85,7 +85,7 @@ __maybe_unused static int set_pte_flags(pte_t *entry, vmr_prop_t flags,
         else {
                 if (!(flags & VMR_EXEC))
                         entry->l3_page.UXN = AARCH64_MMU_ATTR_PAGE_UXN;
-                // EL1 cannot directly execute EL0 accessiable region.
+                // EL1 cannot directly execute EL0 accessible region.
                 entry->l3_page.PXN = AARCH64_MMU_ATTR_PAGE_PXN;
         }
 
@@ -252,21 +252,21 @@ void free_page_table(void *pgtbl)
         /* L0 page table */
         l0_ptp = (ptp_t *)pgtbl;
 
-        /* Interate each entry in the l0 page table*/
+        /* Iterate each entry in the l0 page table*/
         for (i = 0; i < PTP_ENTRIES; ++i) {
                 l0_pte = &l0_ptp->ent[i];
                 if (IS_PTE_INVALID(l0_pte->pte))
                         continue;
                 l1_ptp = (ptp_t *)GET_NEXT_PTP(l0_pte);
 
-                /* Interate each entry in the l1 page table*/
+                /* Iterate each entry in the l1 page table*/
                 for (j = 0; j < PTP_ENTRIES; ++j) {
                         l1_pte = &l1_ptp->ent[j];
                         if (IS_PTE_INVALID(l1_pte->pte))
                                 continue;
                         l2_ptp = (ptp_t *)GET_NEXT_PTP(l1_pte);
 
-                        /* Interate each entry in the l2 page table*/
+                        /* Iterate each entry in the l2 page table*/
                         for (k = 0; k < PTP_ENTRIES; ++k) {
                                 l2_pte = &l2_ptp->ent[k];
                                 if (IS_PTE_INVALID(l2_pte->pte))
@@ -345,7 +345,7 @@ int map_range_in_pgtbl(void *pgtbl, vaddr_t va, paddr_t pa, size_t len,
 }
 
 /*
- * Try to relase a lower level page table page (low_ptp).
+ * Try to release a lower level page table page (low_ptp).
  * @high_ptp: the higher level page table page
  * @low_ptp: the next level page table page
  * @index: the index of low_ptp in high ptp entries

--- a/Lab2/kernel/lib/rbtree.c
+++ b/Lab2/kernel/lib/rbtree.c
@@ -55,7 +55,7 @@ static void __rb_change_child(struct rb_root *root,
  *     t1 t2 t3  t4
  * There are three nodes and 4 corresponding subtrees, that's why this
  * function is named as connect34.
- * Differente kinds of double rotations only need to set arguments of
+ * Different kinds of double rotations only need to set arguments of
  * this function according to their targeted tree patterns. See codes
  * in __rb_insert_color and __rb_erase_color for concrete examples.
  */
@@ -389,7 +389,7 @@ static struct rb_node *__rb_erase(struct rb_root *this, struct rb_node *node,
                         __rb_change_child(this, parent, succ, succ_child);
 
                         // replace node with succ, succ would inherit node's
-                        // parent, color and **chilren**.
+                        // parent, color and **children**.
                         rb_replace_node(this, node, succ);
                 }
         }
@@ -492,7 +492,7 @@ static void __rb_erase_color(struct rb_root *root, struct rb_node *parent,
                                                  *        / \               / \
                                                  *       S1  S2            S1 S2
                                                  * Subtree P has 1 lower
-                                                 * blackheight than slibings of
+                                                 * blackheight than siblings of
                                                  * P. (X has 1 lower blackheight
                                                  * than S before). So we let
                                                  * @node = P and continue

--- a/Lab2/kernel/mm/buddy.c
+++ b/Lab2/kernel/mm/buddy.c
@@ -132,7 +132,7 @@ struct page *buddy_get_pages(struct phys_mem_pool *pool, int order)
 
         if (unlikely(order >= BUDDY_MAX_ORDER)) {
                 kwarn("ChCore does not support allocating such too large "
-                      "contious physical memory\n");
+                      "continuous physical memory\n");
                 return NULL;
         }
 

--- a/Lab2/kernel/mm/kmalloc.c
+++ b/Lab2/kernel/mm/kmalloc.c
@@ -30,7 +30,7 @@ void *_get_pages(int order, bool is_record)
         int i;
         void *addr;
 
-        /* Try to get continous physical memory pages from one physmem pool. */
+        /* Try to get continuous physical memory pages from one physmem pool. */
         for (i = 0; i < physmem_map_num; ++i) {
                 page = buddy_get_pages(&global_mem[i], order);
                 if (page)

--- a/Lab2/kernel/mm/pgfault_handler.c
+++ b/Lab2/kernel/mm/pgfault_handler.c
@@ -42,7 +42,7 @@ static void dump_pgfault_error(void)
  * Step-1: get PA of page containing fault_addr, so as kernal VA of that page
  * Step-2: allocate a new page and record in VMR
  * Step-3: copy using kernel VA to new page
- * Step-4(?): update VMR perm (How and when? Neccessary?)
+ * Step-4(?): update VMR perm (How and when? Necessary?)
  * Step-5: update PTE permission and PPN
  * Step-6: Flush TLB of user virtual page(user_vpa)
  */
@@ -308,7 +308,7 @@ int handle_trans_fault(struct vmspace *vmspace, vaddr_t fault_addr)
  * instruction cannot be satisfied by permission of a page in page table
  * when **executing** the instruction by the hardware. To handle a
  * permission fault, we have to differentiate permissions in the VMR where
- * the faulting page belongs(declared_perm) and the priviledge needed
+ * the faulting page belongs(declared_perm) and the privilege needed
  * by the faulting instruction(desired_perm). In some cases, a permission
  * fault is demanded by us. For instance, if a page is shared through CoW,
  * it's mapped as readonly sharing at first, and there would be a permission

--- a/Lab2/kernel/mm/slab.c
+++ b/Lab2/kernel/mm/slab.c
@@ -226,7 +226,7 @@ static void try_return_slab_to_buddy(struct slab_header *slab, int order)
         free_pages_without_record(slab);
 }
 
-/* Interfaces exported to the kernel/mm moudule */
+/* Interfaces exported to the kernel/mm module */
 
 void init_slab(void)
 {

--- a/Lab2/kernel/mm/vmspace.c
+++ b/Lab2/kernel/mm/vmspace.c
@@ -257,7 +257,7 @@ int vmspace_init(struct vmspace *vmspace, unsigned long pcid)
         memset((void *)vmspace->pgtbl, 0, PAGE_SIZE);
         vmspace->pcid = pcid;
 
-        /* Architecture-dependent initilization */
+        /* Architecture-dependent initialization */
         arch_vmspace_init(vmspace);
 
         /*
@@ -407,7 +407,7 @@ static int check_unmap(struct vmspace *vmspace, vaddr_t va, size_t len,
 
 /*
  * Unmap routine: unmap a virtual memory range.
- * Current limitation: only supports unmap multiple whole exsiting vmrs.
+ * Current limitation: only supports unmap multiple whole existing vmrs.
  */
 int vmspace_unmap_range(struct vmspace *vmspace, vaddr_t va, size_t len)
 {


### PR DESCRIPTION
# 简介

## 问题变更

- [x] 漏洞修复
- [ ] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

## 介绍

fix some typos (spelling) in the comments and log messages in Lab 1 and Lab 2

