### PR TITLE
Lab3: fix docs and sanitize macro defs

### DIFF
--- a/Lab3/kernel/object/thread.c
+++ b/Lab3/kernel/object/thread.c
@@ -106,12 +106,6 @@ void thread_deinit(void *thread_ptr)
         /* The thread struct itself will be freed in __free_object */
 }
 
-#define PFLAGS2VMRFLAGS(PF)                                           \
-        (((PF) & PF_X ? VMR_EXEC : 0) | ((PF) & PF_W ? VMR_WRITE : 0) \
-         | ((PF) & PF_R ? VMR_READ : 0))
-
-#define OFFSET_MASK (0xFFF)
-
 /* Required by LibC */
 void prepare_env(char *env, vaddr_t top_vaddr, char *name,
                  struct process_metadata *meta);

--- a/Pages/Lab3/fault.md
+++ b/Pages/Lab3/fault.md
@@ -15,8 +15,8 @@ AArch64 中的每个异常级别都有其自己独立的异常向量表，其虚
 
 在 ChCore 中，仅使用了 EL0 和 EL1 两个异常级别，因此仅需要对 EL1 异常向量表进行初始化即可。在本实验中，ChCore 内除系统调用外所有的同步异常均交由 `handle_entry_c` 函数进行处理。遇到异常时，硬件将根据 ChCore 的配置执行对应的汇编代码，将异常类型和当前异常处理程序条目类型作为参数传递，对于 sync_el1h 类型的异常，跳转 `handle_entry_c` 使用 C 代码处理异常。对于 irq_el1t、fiq_el1t、fiq_el1h、error_el1t、error_el1h、sync_el1t 则跳转 `unexpected_handler` 处理异常。
 
-> [!CODING] 练习题
-> 按照前文所述的表格填写 `kernel/arch/aarch64/irq/irq_entry.S` 中的异常向量表，并且增加对应的函数跳转操作。
+> [!CODING] 练习题5
+> 按照前文所述的表格填写 `kernel/arch/aarch64/irq/irq_entry.S` 中的异常向量表，并且增加对应的函数跳转操作
 
 ---
 > [!SUCCESS]


### PR DESCRIPTION
# 简介

## 问题变更

- [x] 漏洞修复
- [x] 文档更新

## 介绍

请附上一个本PR所解决问题的简介

1. 修复 lab3中错误且未使用的宏定义
2. 修复Lab3 doc typo
