### PR TITLE
fix: NixOS/podman compatibility issue

### DIFF
--- a/Lab6/chbuild
+++ b/Lab6/chbuild
@@ -93,7 +93,7 @@ ci_sync() {
     if [ ! -d $repo_tool_dir ]; then
         _ci_init $@
     fi
-    repo sync -c --no-clone-bundle --no-tags -j$(nproc --all) -m $ci_manifest_name  --fetch-submodules
+    repo sync -c --no-clone-bundle --no-tags -j$(nproc --all) -m $ci_manifest_name --fetch-submodules
 }
 
 _init() {
@@ -139,7 +139,7 @@ config() {
     _check_config_file
     _config_ask
     _sync_config_with_cache
-    _echo_succ "Config syned to \`$config_file\` file."
+    _echo_succ "Config synced to \`$config_file\` file."
 }
 
 menuconfig() {
@@ -159,7 +159,7 @@ rambuild() {
     _echo_info "Building ramdisk..."
 
     cmake --build $cmake_build_dir --target rambuild --parallel $(nproc)
-    
+
     _echo_succ "Succeeded to rebuild ramdisk"
 }
 
@@ -167,7 +167,7 @@ build() {
     _check_config_file
     _config_ask
     _sync_config_with_cache
-    _echo_succ "Config syned to \`$config_file\` file."
+    _echo_succ "Config synced to \`$config_file\` file."
 
     if [ -z "$1" ]; then
         build_target="all"
@@ -265,7 +265,7 @@ _update_submodules() {
 }
 
 _docker_run() {
-    if [ -f /.dockerenv ]; then
+    if [[ -f /.dockerenv || -f /run/.containerenv ]]; then
         # we are already in docker container
         $@
     else

--- a/Scripts/chbuild
+++ b/Scripts/chbuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2023 Institute of Parallel And Distributed Systems (IPADS), Shanghai Jiao Tong University (SJTU) Licensed under the Mulan PSL v2.
 # You can use this software according to the terms and conditions of the Mulan PSL v2.
 # You may obtain a copy of Mulan PSL v2 at:
@@ -92,7 +92,7 @@ ci_sync() {
     if [ ! -d $repo_tool_dir ]; then
         _ci_init $@
     fi
-    repo sync -c --no-clone-bundle --no-tags -j$(nproc --all) -m $ci_manifest_name  --fetch-submodules
+    repo sync -c --no-clone-bundle --no-tags -j$(nproc --all) -m $ci_manifest_name --fetch-submodules
 }
 
 _init() {
@@ -138,7 +138,7 @@ config() {
     _check_config_file
     _config_ask
     _sync_config_with_cache
-    _echo_succ "Config syned to \`$config_file\` file."
+    _echo_succ "Config synced to \`$config_file\` file."
 }
 
 menuconfig() {
@@ -158,7 +158,7 @@ rambuild() {
     _echo_info "Building ramdisk..."
 
     cmake --build $cmake_build_dir --target rambuild --parallel $(nproc)
-    
+
     _echo_succ "Succeeded to rebuild ramdisk"
 }
 
@@ -166,7 +166,7 @@ build() {
     _check_config_file
     _config_ask
     _sync_config_with_cache
-    _echo_succ "Config syned to \`$config_file\` file."
+    _echo_succ "Config synced to \`$config_file\` file."
 
     if [ -z "$1" ]; then
         build_target="all"
@@ -264,7 +264,7 @@ _update_submodules() {
 }
 
 _docker_run() {
-    if [ -f /.dockerenv ]; then
+    if [[ -f /.dockerenv || -f /run/.containerenv ]]; then
         # we are already in docker container
         $@
     else

--- a/Scripts/gendeps.sh
+++ b/Scripts/gendeps.sh
@@ -26,9 +26,12 @@ make_labs_env() {
 	"*suse*")
 		TOOLCHAINS["gdb"]="gdb"
 		;;
+	"nixos")
+		TOOLCHAINS["gdb"]="gdb"
+		;;
 	*)
 		error "Unsupported Linux Distribution: ${DIST}"
-		error "Supported OS Distributions are: ubuntu/debian, fedora, arch, gentoo, opensuse"
+		error "Supported OS Distributions are: ubuntu/debian, fedora, arch, gentoo, opensuse, nixos"
 		fatal "If you want to add support for your distribution, please submit a PR."
 		;;
 	esac


### PR DESCRIPTION
# 简介

## 问题变更

- [x] 漏洞修复
- [ ] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

- ## 介绍

- Set all bash entries to `/usr/bin/env bash` (as #53 have omitted `chbuild` and `patch.py`)
- Additionally check `/run/.containerenv` in container environment for podman compatibility.

