### PR TITLE
feat: add Nix devshell for lab/mdBook development

### DIFF
--- a/Nix/mdbook-last-changed.nix
+++ b/Nix/mdbook-last-changed.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-last-changed";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "badboy";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-5B0j/HjuN8jpTVldRR1e79VQxhhvIN0yCDqt9teEKUc=";
+  };
+
+  cargoHash = "sha256-aPIH4mzjuFvaGacskEfMI9Ufh1iak9gxshNLBb9xEbI=";
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = {
+    description = "A preprocessor for mdbook to add a page's last change date and a link to the commit on every page";
+    homepage = "https://github.com/badboy/mdbook-last-changed";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      definfo
+    ];
+  };
+}

--- a/Nix/rs-mdbook-callouts.nix
+++ b/Nix/rs-mdbook-callouts.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rs-mdbook-callouts";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "ToolmanP";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-HKSVAga8IHgaT+It8pv/RNWRt851IFDLhcWmc/3pm/g=";
+  };
+
+  cargoHash = "sha256-5/J7yDxLJLeDVQ/l4LmRCYQdTt6AELDdNJNZFGf8aTw=";
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = {
+    description = "mdBook preprocessor to add Obsidian flavored callouts + Github alerts to your book";
+    mainProgram = "mdbook-callouts";
+    homepage = "https://github.com/ToolmanP/rs-mdbook-callouts";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      definfo
+    ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "revCount": 724962,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.724962%2Brev-d70bd19e0a38ad4790d3913bf08fcbfc9eeca507/0193ec4a-02cd-7c6d-bad8-825029076205/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "A Nix-flake-based C/C++ development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      devShells = forEachSupportedSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            buildInputs =
+              with pkgs;
+              [
+                # For builds
+                clang-tools
+                cmake
+                python3
+                pkgsCross.aarch64-multiplatform.bintools
+              ]
+              ++ lib.optionals stdenv.hostPlatform.isLinux [
+                # macOS build only has the qemu-system files.
+                qemu
+                # Currently GDB is unsupported on aarch64-darwin.
+                gdb
+              ];
+          };
+          mdBook = pkgs.mkShell {
+            buildInputs =
+              let
+                rs-mdbook-callouts = pkgs.callPackage ./Nix/rs-mdbook-callouts.nix { };
+                mdbook-last-changed = pkgs.callPackage ./Nix/mdbook-last-changed.nix { };
+              in
+              with pkgs;
+              [
+                rs-mdbook-callouts
+                mdbook
+                mdbook-toc
+                mdbook-last-changed
+                mdbook-mermaid
+              ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
# 简介

## 问题变更

- [ ] 漏洞修复
- [x] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

## 介绍

Add a Nix-flakes-based development shell for lab / mdBook development. Tested on x86_64-linux.
Known issue: Due to GDB issue on aarch64-darwin, Apple Silicon users may have to work around themselves :(
