### PR TITLE
chore(CpuLab): fix deprecation in GUI interpreter result related code

### DIFF
--- a/CpuLab/sim/pipe/psim.c
+++ b/CpuLab/sim/pipe/psim.c
@@ -850,7 +850,7 @@ int simResetCmd(ClientData clientData, Tcl_Interp *interp,
 {
     sim_interp = interp;
     if (argc != 1) {
-	interp->result = "No arguments allowed";
+	Tcl_SetResult(interp, "No arguments allowed", NULL);
 	return TCL_ERROR;
     }
     sim_reset();
@@ -858,7 +858,7 @@ int simResetCmd(ClientData clientData, Tcl_Interp *interp,
 	free_mem(mem);
 	mem = copy_mem(post_load_mem);
     }
-    interp->result = stat_name(STAT_AOK);
+    Tcl_SetResult(interp, stat_name(STAT_AOK), NULL);
     return TCL_OK;
 }
 
@@ -869,20 +869,20 @@ int simLoadCodeCmd(ClientData clientData, Tcl_Interp *interp,
     word_t code_count;
     sim_interp = interp;
     if (argc != 2) {
-	interp->result = "One argument required";
+	Tcl_SetResult(interp, "One argument required", NULL);
 	return TCL_ERROR;
     }
     code_file = fopen(argv[1], "r");
     if (!code_file) {
 	sprintf(tcl_msg, "Couldn't open code file '%s'", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     sim_reset();
     code_count = load_mem(mem, code_file, 0);
     post_load_mem = copy_mem(mem);
     sprintf(tcl_msg, "%lld", code_count);
-    interp->result = tcl_msg;
+    Tcl_SetResult(interp, tcl_msg, NULL);
     fclose(code_file);
     return TCL_OK;
 }
@@ -892,23 +892,23 @@ int simLoadDataCmd(ClientData clientData, Tcl_Interp *interp,
 {
     FILE *data_file;
     word_t word_count = 0;
-    interp->result = "Not implemented";
+    Tcl_SetResult(interp, "Not implemented", NULL);
     return TCL_ERROR;
 
 
     sim_interp = interp;
     if (argc != 2) {
-	interp->result = "One argument required";
+	Tcl_SetResult(interp, "One argument required", NULL);
 	return TCL_ERROR;
     }
     data_file = fopen(argv[1], "r");
     if (!data_file) {
 	sprintf(tcl_msg, "Couldn't open data file '%s'", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     sprintf(tcl_msg, "%lld", word_count);
-    interp->result = tcl_msg;
+    Tcl_SetResult(interp, tcl_msg, NULL);
     fclose(data_file);
     return TCL_OK;
 }
@@ -922,18 +922,18 @@ int simRunCmd(ClientData clientData, Tcl_Interp *interp,
     cc_t cc;
     sim_interp = interp;
     if (argc > 2) {
-	interp->result = "At most one argument allowed";
+	Tcl_SetResult(interp, "At most one argument allowed", NULL);
 	return TCL_ERROR;
     }
     if (argc >= 2 &&
 	(sscanf(argv[1], "%lld", &cycle_limit) != 1 ||
 	 cycle_limit < 0)) {
 	sprintf(tcl_msg, "Cannot run for '%s' cycles!", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     sim_run_pipe(cycle_limit + 5, cycle_limit, &status, &cc);
-    interp->result = stat_name(status);
+    Tcl_SetResult(interp, stat_name(status), NULL);
     return TCL_OK;
 }
 
@@ -942,10 +942,10 @@ int simModeCmd(ClientData clientData, Tcl_Interp *interp,
 {
     sim_interp = interp;
     if (argc != 2) {
-	interp->result = "One argument required";
+	Tcl_SetResult(interp, "One argument required", NULL);
 	return TCL_ERROR;
     }
-    interp->result = argv[1];
+    Tcl_SetResult(interp, argv[1], NULL);
     if (strcmp(argv[1], "wedged") == 0)
 	sim_mode = S_WEDGED;
     else if (strcmp(argv[1], "stall") == 0)
@@ -954,7 +954,7 @@ int simModeCmd(ClientData clientData, Tcl_Interp *interp,
 	sim_mode = S_FORWARD;
     else {
 	sprintf(tcl_msg, "Unknown mode '%s'", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     return TCL_OK;
@@ -991,7 +991,7 @@ void signal_register_update(reg_id_t r, word_t val) {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to signal register set\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1002,7 +1002,7 @@ void create_memory_display() {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Command '%s' failed\n", tcl_msg);
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     } else {
 	word_t i;
 	for (i = 0; i < memCnt && code == TCL_OK; i+=8) {
@@ -1017,7 +1017,7 @@ void create_memory_display() {
 	}
 	if (code != TCL_OK) {
 	    fprintf(stderr, "Couldn't set memory value\n");
-	    fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	    fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
 	}
     }
 }
@@ -1052,7 +1052,7 @@ void set_memory(word_t addr, word_t val) {
 	if (code != TCL_OK) {
 	    fprintf(stderr, "Couldn't set memory value 0x%llx to 0x%llx\n",
 		    addr, val);
-	    fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	    fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
 	}
     }
 }
@@ -1066,7 +1066,7 @@ void show_cc(cc_t cc)
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to display condition codes\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1078,7 +1078,7 @@ void show_stat(stat_t stat)
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to display status\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1093,7 +1093,7 @@ void show_cpi() {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to display CPI\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1107,7 +1107,7 @@ void signal_sources() {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to signal forwarding sources\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1117,7 +1117,7 @@ void signal_register_clear() {
     code = Tcl_Eval(sim_interp, "clearReg");
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to signal register clear\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1131,7 +1131,7 @@ void report_line(word_t line_no, word_t addr, char *hex, char *text) {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to report code line 0x%llx\n", addr);
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1187,7 +1187,7 @@ void report_pc(unsigned fpc, unsigned char fpcv,
     status = Tcl_Eval(sim_interp, Tcl_DStringValue(&cmd));
     if (status != TCL_OK) {
 	fprintf(stderr, "Failed to report pipe code '%s'\n", code);
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1201,7 +1201,7 @@ void report_state(char *id, word_t current, char *txt)
 	fprintf(stderr, "Failed to report pipe status\n");
 	fprintf(stderr, "\tStage %s.%s, status '%s'\n",
 		id, current ? "current" : "next", txt);
-	fprintf(stderr, "\tError Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "\tError Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 

--- a/CpuLab/sim/seq/ssim.c
+++ b/CpuLab/sim/seq/ssim.c
@@ -877,7 +877,7 @@ int simResetCmd(ClientData clientData, Tcl_Interp *interp,
 {
     sim_interp = interp;
     if (argc != 1) {
-	interp->result = "No arguments allowed";
+	Tcl_SetResult(interp, "No arguments allowed", NULL);
 	return TCL_ERROR;
     }
     sim_reset();
@@ -885,7 +885,7 @@ int simResetCmd(ClientData clientData, Tcl_Interp *interp,
 	free_mem(mem);
 	mem = copy_mem(post_load_mem);
     }
-    interp->result = stat_name(STAT_AOK);
+    Tcl_SetResult(interp, stat_name(STAT_AOK), NULL);
     return TCL_OK;
 }
 
@@ -896,20 +896,20 @@ int simLoadCodeCmd(ClientData clientData, Tcl_Interp *interp,
     word_t code_count;
     sim_interp = interp;
     if (argc != 2) {
-	interp->result = "One argument required";
+	Tcl_SetResult(interp, "One argument required", NULL);
 	return TCL_ERROR;
     }
     object_file = fopen(argv[1], "r");
     if (!object_file) {
 	sprintf(tcl_msg, "Couldn't open code file '%s'", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     sim_reset();
     code_count = load_mem(mem, object_file, 0);
     post_load_mem = copy_mem(mem);
     sprintf(tcl_msg, "%lld", code_count);
-    interp->result = tcl_msg;
+    Tcl_SetResult(interp, tcl_msg, NULL);
     fclose(object_file);
     return TCL_OK;
 }
@@ -919,23 +919,23 @@ int simLoadDataCmd(ClientData clientData, Tcl_Interp *interp,
 {
     FILE *data_file;
     word_t word_count = 0;
-    interp->result = "Not implemented";
+    Tcl_SetResult(interp, "Not implemented", NULL);
     return TCL_ERROR;
 
 
     sim_interp = interp;
     if (argc != 2) {
-	interp->result = "One argument required";
+	Tcl_SetResult(interp, "One argument required", NULL);
 	return TCL_ERROR;
     }
     data_file = fopen(argv[1], "r");
     if (!data_file) {
 	sprintf(tcl_msg, "Couldn't open data file '%s'", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     sprintf(tcl_msg, "%lld", word_count);
-    interp->result = tcl_msg;
+    Tcl_SetResult(interp, tcl_msg, NULL);
     fclose(data_file);
     return TCL_OK;
 }
@@ -949,18 +949,18 @@ int simRunCmd(ClientData clientData, Tcl_Interp *interp,
     cc_t cc;
     sim_interp = interp;
     if (argc > 2) {
-	interp->result = "At most one argument allowed";
+	Tcl_SetResult(interp, "At most one argument allowed", NULL);
 	return TCL_ERROR;
     }
     if (argc >= 2 &&
 	(sscanf(argv[1], "%lld", &step_limit) != 1 ||
 	 step_limit < 0)) {
 	sprintf(tcl_msg, "Cannot run for '%s' cycles!", argv[1]);
-	interp->result = tcl_msg;
+	Tcl_SetResult(interp, tcl_msg, NULL);
 	return TCL_ERROR;
     }
     sim_run(step_limit, &run_status, &cc);
-    interp->result = stat_name(run_status);
+    Tcl_SetResult(interp, stat_name(status), NULL);
     return TCL_OK;
 }
 
@@ -992,7 +992,7 @@ void signal_register_update(reg_id_t r, word_t val) {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to signal register set\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1003,7 +1003,7 @@ void create_memory_display() {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Command '%s' failed\n", tcl_msg);
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     } else {
 	word_t i;
 	for (i = 0; i < memCnt && code == TCL_OK; i+=8) {
@@ -1018,7 +1018,7 @@ void create_memory_display() {
 	}
 	if (code != TCL_OK) {
 	    fprintf(stderr, "Couldn't set memory value\n");
-	    fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	    fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
 	}
     }
 }
@@ -1053,7 +1053,7 @@ void set_memory(word_t addr, word_t val) {
 	if (code != TCL_OK) {
 	    fprintf(stderr, "Couldn't set memory value 0x%llx to 0x%llx\n",
 		    addr, val);
-	    fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	    fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
 	}
     }
 }
@@ -1067,7 +1067,7 @@ void show_cc(cc_t cc)
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to display condition codes\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1077,7 +1077,7 @@ void signal_register_clear() {
     code = Tcl_Eval(sim_interp, "clearReg");
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to signal register clear\n");
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1091,7 +1091,7 @@ void report_line(word_t line_no, word_t addr, char *hex, char *text) {
     code = Tcl_Eval(sim_interp, tcl_msg);
     if (code != TCL_OK) {
 	fprintf(stderr, "Failed to report code line 0x%llx\n", addr);
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1118,7 +1118,7 @@ void report_pc(word_t pc)
     t_status = Tcl_Eval(sim_interp, Tcl_DStringValue(&cmd));
     if (t_status != TCL_OK) {
 	fprintf(stderr, "Failed to report code '%s'\n", code);
-	fprintf(stderr, "Error Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "Error Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 
@@ -1132,7 +1132,7 @@ void report_state(char *id, char *txt)
 	fprintf(stderr, "Failed to report processor status\n");
 	fprintf(stderr, "\tStage %s, status '%s'\n",
 		id, txt);
-	fprintf(stderr, "\tError Message was '%s'\n", sim_interp->result);
+	fprintf(stderr, "\tError Message was '%s'\n", Tcl_GetStringResult(sim_interp));
     }
 }
 


### PR DESCRIPTION


# 简介

## 问题变更

- [x] 漏洞修复
- [ ] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

## 介绍

CHANGES:

* Changed `interp->result` to `Tcl_SetResult` / `Tcl_GetStringResult`

NOTE:

* In tcl 8.5, it is suggested to use `Tcl_SetResult` / `Tcl_GetStringResult` to set / read interpreter's result against directly accessing them

* Directly accessing `interp->result` is deprecated in tcl 8.6, this fix enables GUI to compile without need to pass `USE_INTERP_RESULT` constant in tcl 8.6

