### PR TITLE
chore ： remove useless gendeps.sh command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,6 @@
 			"twxs.cmake",
 			"dan-c-underwood.arm"
 		]
-	},
-	"postCreateCommand": "bash Scripts/gendeps.sh"
+	}
   }
 }


### PR DESCRIPTION
# 简介
删除devcontainer.json中gendep.sh内容，这个文件在 a482de7f70 中被删除了


## 问题变更

- [ ] 漏洞修复
- [ ] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

## 介绍

请附上一个本PR所解决问题的简介

Fixes # (issue)
