### PR TITLE
Fix/variable usage bugs in `cap_group_init_user()`

### DIFF
--- a/Lab3/kernel/object/cap_group.c
+++ b/Lab3/kernel/object/cap_group.c
@@ -115,7 +115,7 @@ __maybe_unused static int cap_group_init_user(struct cap_group *cap_group, unsig
                                struct cap_group_args *args)
 {
 #ifdef CHCORE_OPENTRUSTEE
-        if (check_user_addr_range((vaddr_t)args.puuid, sizeof(TEE_UUID)) != 0)
+        if (check_user_addr_range((vaddr_t)args->puuid, sizeof(TEE_UUID)) != 0)
                 return -EINVAL;
 #endif /* CHCORE_OPENTRUSTEE */
 
@@ -125,11 +125,11 @@ __maybe_unused static int cap_group_init_user(struct cap_group *cap_group, unsig
 
         cap_group->pid = args->pid;
 #ifdef CHCORE_OPENTRUSTEE
-        cap_group->heap_size_limit = args.heap_size;
+        cap_group->heap_size_limit = args->heap_size;
         /* pid used in OH-TEE */
-        if (args.puuid) {
+        if (args->puuid) {
                 copy_from_user(&cap_group->uuid,
-                               (void *)args.puuid,
+                               (void *)args->puuid,
                                sizeof(TEE_UUID));
         } else {
                 memset(&cap_group->uuid, 0, sizeof(TEE_UUID));


### PR DESCRIPTION
# 简介

## 问题变更

- [x] 漏洞修复
- [ ] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

## 介绍

请附上一个本PR所解决问题的简介

Fixes # (issue)

The function `cap_group_init_user()` in `cap_group.c` takes `struct cap_group *cap_group` and `struct cap_group_args *args` as arguments, but inside the `#ifdef CHCORE_OPENTRUSTEE` blocks. They are used in wrong way which can cause an issue if `CHCORE_OPENTRUSTEE` is defined.

This PR fixes the variable name usage as well pointer variable accessing in this `#ifdef` block.
