### PR TITLE
fix(scripts): use POSIX-compatible redirection in kernel.mk grade target

### DIFF
--- a/Scripts/kernel.mk
+++ b/Scripts/kernel.mk
@@ -54,7 +54,7 @@ gdb:
 	$(Q)$(GDB) --nx -x $(SCRIPTS)/gdb/gdbinit
 
 grade:  
-	$(Q)$(MAKE) distclean &> /dev/null
+	$(Q)$(MAKE) distclean > /dev/null 2>&1
 	$(Q)(test -f $(LABDIR)/.config && cp $(LABDIR)/.config $(LABDIR)/.config.bak) || :
 	$(Q)$(MAKE) build
 	$(Q)$(DOCKER_RUN) $(GRADER) -t $(TIMEOUT) -f $(LABDIR)/scores.json $(GRADER_V) -s $(SERIAL) make SERIAL=$(SERIAL) qemu-grade


### PR DESCRIPTION
`&>` is a bash-specific syntax. On Ubuntu where `/bin/sh` points to dash, it is parsed as backgrounding (`&`) plus empty redirection (`>`), causing `distclean` and `build` to run concurrently in `make grade`.

Replace `&> /dev/null` with the POSIX-compatible `> /dev/null 2>&1`.

# 简介

## 问题变更

- [x] 漏洞修复
- [ ] 新特性
- [ ] 颠覆性特性
- [ ] 文档更新

## 介绍

在基于 `ipads/oslab:25.03` 镜像（Ubuntu 20.04）的 Docker 容器中运行 `make grade` 时，`Scripts/kernel.mk` 第 57 行会执行失败。

原因：该行使用了 `&>` 重定向语法，这是 bash 特有的扩展语法。Ubuntu 20.04 中 `/bin/sh` 默认指向 dash（Debian Almquist Shell），而 GNU Make 默认使用 `/bin/sh` 执行命令。dash 不支持 `&>`，会将其解析为两个独立的操作：`make distclean &`（后台执行）和 `> /dev/null`（空命令重定向）。结果是 `distclean` 在后台运行的同时 `build` 立即开始执行，两者并发导致构建失败。

修复：将 `&> /dev/null` 替换为 POSIX 兼容的 `> /dev/null 2>&1`，确保在所有 POSIX sh 实现下都能正确串行执行。